### PR TITLE
[refactor] : 받은질문조회 리팩터링

### DIFF
--- a/src/main/java/toy/withme58/api/qustion/business/QuestionBusiness.java
+++ b/src/main/java/toy/withme58/api/qustion/business/QuestionBusiness.java
@@ -5,6 +5,7 @@ import toy.withme58.api.common.annotation.Business;
 import toy.withme58.api.qustion.converter.QuestionConverter;
 import toy.withme58.api.qustion.dto.QuestionsDto;
 import toy.withme58.api.qustion.dto.response.MyQuestionResponse;
+import toy.withme58.api.qustion.dto.response.SendingAnswerResponse;
 import toy.withme58.api.qustion.service.QuestionService;
 import toy.withme58.db.answer.AnswerEntity;
 
@@ -22,11 +23,15 @@ public class QuestionBusiness {
 
         List<QuestionsDto> questionsDto = questions.stream()
                 .map(q -> {
-                    String questionTitle = questionService.findQuestionTitle(q.getId());
+                    String questionTitle = questionService.findQuestionTitle(q.getQuestion().getId());
                     String senderName = questionService.findFriendNameBySenderId(q.getSenderId());
                     return questionConverter.questionsDto(questionTitle, senderName, q);
                 }).toList();
 
         return questionConverter.questionResponse(questionsDto);
+    }
+
+    public SendingAnswerResponse sendingAnswer(Long memberId, Long senderId) {//senderId는 질문한사람!!답변은 받는 것
+        return null;
     }
 }

--- a/src/main/java/toy/withme58/api/qustion/converter/QuestionConverter.java
+++ b/src/main/java/toy/withme58/api/qustion/converter/QuestionConverter.java
@@ -13,7 +13,8 @@ public class QuestionConverter {
 
     public QuestionsDto questionsDto(String questionTitle, String senderName, AnswerEntity question) {
         return QuestionsDto.builder().questionName(questionTitle)
-                .friendName(senderName).friendId(question.getId()).build();
+                .friendName(senderName).friendId(question.getSenderId()).answerId(question.getId())
+                .build();
     }
 
     public MyQuestionResponse questionResponse(List<QuestionsDto> questions) {

--- a/src/main/java/toy/withme58/api/qustion/dto/QuestionsDto.java
+++ b/src/main/java/toy/withme58/api/qustion/dto/QuestionsDto.java
@@ -9,4 +9,5 @@ public class QuestionsDto {
     private String questionName;
     private String friendName;
     private Long friendId;
+    private Long answerId;
 }

--- a/src/main/java/toy/withme58/api/qustion/dto/request/SendingAnswerRequest.java
+++ b/src/main/java/toy/withme58/api/qustion/dto/request/SendingAnswerRequest.java
@@ -6,4 +6,5 @@ import lombok.Getter;
 public class SendingAnswerRequest {
     private Long friendId; //질문 보낸 친구의 아이
     private String answer;
+    private Long answerId;
 }

--- a/src/main/java/toy/withme58/db/answer/AnswerRepository.java
+++ b/src/main/java/toy/withme58/db/answer/AnswerRepository.java
@@ -1,6 +1,7 @@
 package toy.withme58.db.answer;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,5 +19,4 @@ public interface AnswerRepository extends JpaRepository<AnswerEntity, Long> {
     Optional<AnswerEntity> findFirstByReceiverIdAndQuestionIdOrderByIdDesc(Long receiverId, Long questionId);
 
     List<AnswerEntity> findAllByReceiverId(Long receiverId);
-
 }


### PR DESCRIPTION
<!-- 제목 = [기능] : 작업명 -->
<!-- ex) [feat] : Docker 기반의 CI/CD -->

## 🔧 작업 내용
머지된 받은 질문 조회 API에서 수정사항이 있어야 할 것 같습니다
답변 전송 API에서 다대다 관계때문에 questionId와 senderId, receiverId로 칼럼을 가져오기에는 조금 복잡해질 것 같아요. question이 quetion객체로 엔티티에 들어와있어서요...
그래서 아예 answerId(이건 PK값!)을 받으면 답변 전송 API시에도 편할 것 같아서요, 받은 질문 조회 API에서 아예 저장된 answer db의 PK값을 프론트에 response로 전해주는 방식으로 리팩터링 해 보았습니다. 이견있으시면 편하게 말해주세요
그리고 코드에서도 수정사항이 있었는데요,
<img width="749" alt="image" src="https://github.com/user-attachments/assets/b5847b42-a6fd-45bd-9df8-922136fda22c">
에서
`String questionTitle = questionService.findQuestionTitle(q.getQuestion().getId());`
이 부분이 수정되었어요. 커밋에서도 볼 수 있겠지만 원래는 `q.getId()`였는데요, 생각해보니까 이러면 quesionId값이 아니라 answer db의 PK id 값을 받게 되더라구요? 그렇지 않나요??

return null로 되어있는것은 답변전송 API를 개발하다가 리팩터링 지점을 발견해서 우선 오류가 안나도록(빨간줄그어지는거) null로 처리해둔 것이구요, 이 pr 이후에 작업할 예정입니다.