### PR TITLE
[feat] : 답변 전송 API 개발

### DIFF
--- a/src/main/java/toy/withme58/api/qustion/business/QuestionBusiness.java
+++ b/src/main/java/toy/withme58/api/qustion/business/QuestionBusiness.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import toy.withme58.api.common.annotation.Business;
 import toy.withme58.api.qustion.converter.QuestionConverter;
 import toy.withme58.api.qustion.dto.QuestionsDto;
+import toy.withme58.api.qustion.dto.request.SendingAnswerRequest;
 import toy.withme58.api.qustion.dto.response.MyQuestionResponse;
 import toy.withme58.api.qustion.dto.response.SendingAnswerResponse;
 import toy.withme58.api.qustion.service.QuestionService;
@@ -31,7 +32,9 @@ public class QuestionBusiness {
         return questionConverter.questionResponse(questionsDto);
     }
 
-    public SendingAnswerResponse sendingAnswer(Long memberId, Long senderId) {//senderId는 질문한사람!!답변은 받는 것
+    public SendingAnswerResponse sendingAnswer(SendingAnswerRequest request) {//senderId는 질문한사람!!답변은 받는 것
+        questionService.updateAnswer(request.getAnswerId(), request.getAnswer());
+        AnswerEntity answerEntity = questionService.findAnswerById(request.getAnswerId());
         return null;
     }
 }

--- a/src/main/java/toy/withme58/api/qustion/business/QuestionBusiness.java
+++ b/src/main/java/toy/withme58/api/qustion/business/QuestionBusiness.java
@@ -35,6 +35,6 @@ public class QuestionBusiness {
     public SendingAnswerResponse sendingAnswer(SendingAnswerRequest request) {//senderId는 질문한사람!!답변은 받는 것
         questionService.updateAnswer(request.getAnswerId(), request.getAnswer());
         AnswerEntity answerEntity = questionService.findAnswerById(request.getAnswerId());
-        return null;
+        return questionConverter.sendingAnswerResponse(answerEntity);
     }
 }

--- a/src/main/java/toy/withme58/api/qustion/controller/QuestionController.java
+++ b/src/main/java/toy/withme58/api/qustion/controller/QuestionController.java
@@ -2,14 +2,12 @@ package toy.withme58.api.qustion.controller;
 
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import toy.withme58.api.common.annotation.MemberSession;
 import toy.withme58.api.common.api.Api;
 import toy.withme58.api.member.dto.Member;
 import toy.withme58.api.qustion.business.QuestionBusiness;
+import toy.withme58.api.qustion.dto.request.SendingAnswerRequest;
 import toy.withme58.api.qustion.dto.response.MyQuestionResponse;
 import toy.withme58.api.qustion.dto.response.SendingAnswerResponse;
 
@@ -31,7 +29,8 @@ public class QuestionController {
     @PostMapping
     public Api<SendingAnswerResponse> sendingAnswer(
             @Parameter(hidden = true)
-            @MemberSession Member member) {
+            @MemberSession Member member,
+            @RequestBody SendingAnswerRequest request) {
         return null;
     }
 }

--- a/src/main/java/toy/withme58/api/qustion/controller/QuestionController.java
+++ b/src/main/java/toy/withme58/api/qustion/controller/QuestionController.java
@@ -27,10 +27,8 @@ public class QuestionController {
     }
 
     @PostMapping
-    public Api<SendingAnswerResponse> sendingAnswer(
-            @Parameter(hidden = true)
-            @MemberSession Member member,
-            @RequestBody SendingAnswerRequest request) {
-        return null;
+    public Api<SendingAnswerResponse> sendingAnswer(@RequestBody SendingAnswerRequest request) {
+        SendingAnswerResponse sendingAnswerResponse = questionBusiness.sendingAnswer(request);
+        return Api.OK(sendingAnswerResponse);
     }
 }

--- a/src/main/java/toy/withme58/api/qustion/converter/QuestionConverter.java
+++ b/src/main/java/toy/withme58/api/qustion/converter/QuestionConverter.java
@@ -3,7 +3,9 @@ package toy.withme58.api.qustion.converter;
 import toy.withme58.api.common.annotation.Converter;
 import toy.withme58.api.qustion.dto.QuestionsDto;
 import toy.withme58.api.qustion.dto.response.MyQuestionResponse;
+import toy.withme58.api.qustion.dto.response.SendingAnswerResponse;
 import toy.withme58.db.answer.AnswerEntity;
+import toy.withme58.db.answer.enums.AnswerStatus;
 import toy.withme58.db.question.enums.QuestionStatus;
 
 import java.util.List;
@@ -20,5 +22,13 @@ public class QuestionConverter {
     public MyQuestionResponse questionResponse(List<QuestionsDto> questions) {
         return MyQuestionResponse.builder()
                 .question(questions).status(QuestionStatus.REGISTERED.getStatus()).build();
+    }
+
+    public SendingAnswerResponse sendingAnswerResponse(AnswerEntity answerEntity) {
+        String question = answerEntity.getQuestion().getTitle();
+        String answer = answerEntity.getContent();
+        return SendingAnswerResponse.builder()
+                .question(question).answer(answer).status(AnswerStatus.REGISTERED.getStatus())
+                .build();
     }
 }

--- a/src/main/java/toy/withme58/api/qustion/service/QuestionService.java
+++ b/src/main/java/toy/withme58/api/qustion/service/QuestionService.java
@@ -11,7 +11,7 @@ import toy.withme58.db.member.MemberRepository;
 import toy.withme58.db.question.QuestionEntity;
 import toy.withme58.db.question.QuestionRepository;
 
-import java.util.ArrayList;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -40,5 +40,17 @@ public class QuestionService {
     public String findFriendNameBySenderId(Long senderId) {
         return memberRepository.findById(senderId)
                 .orElseThrow(() -> new ApiException(ErrorCode.NULL_POINT)).getName();
+    }
+
+    public void updateAnswer(Long answerId, String answerContent) {
+        AnswerEntity answer = answerRepository.findById(answerId)
+                .orElseThrow(() -> new ApiException(ErrorCode.NULL_POINT));
+        answer.setAnsweredAt(LocalDateTime.now());
+        answer.setContent(answerContent);
+        answer.setStatus(AnswerStatus.REGISTERED);
+    }
+
+    public AnswerEntity findAnswerById(Long answerId) {
+        return answerRepository.findById(answerId).orElseThrow(() -> new ApiException(ErrorCode.NULL_POINT));
     }
 }


### PR DESCRIPTION
<!-- 제목 = [기능] : 작업명 -->
<!-- ex) [feat] : Docker 기반의 CI/CD -->

## 🔧 작업 내용
답변 전송 API를 개발하였습니다!!
로직 진행을 설명드리면 다음과 같습니다.
1. friendId(친구의 멤버아이디)와 answerId(answer db에서의 pk값)와 answer(답변내용)를 request body에서 받습니다.
2. answerId로 answerEntity를 조회하여 AnswerAt(답변 받은 시각), content(답변내용),status(UNREGISTERED -> REGISTERED로 갱신)을 저장해 줍니다.

## ❗️ 질문 사항
간단한 질문사항이 있는데요, 해당 로직에서는 현재 페이지에 접근해 있는 회원의 memberId가 딱히 필요하지 않아
`@Parameter(hidden = true)`
`@MemberSession Member member`
이 값이 들어가지 않았습니다. 그래도 stateful하게 유지되는 것에는 문제가 없는 것이겠죠...? 그냥 로직 상 memberId가 필요할때만 파라미터로 넣고 써도 되는 것 일까요..?? 제가 세션에 관한 이해도가 좀 낮아서 질문드려요ㅜ