### PR TITLE
[refactor] : 엔티티 관련 코드 개선

### DIFF
--- a/src/main/java/toy/withme58/api/home/service/HomeService.java
+++ b/src/main/java/toy/withme58/api/home/service/HomeService.java
@@ -112,6 +112,7 @@ public class HomeService {
         return member.getId();
     }
 
+    @Transactional
     public void saveQuestion(AnswerEntity answer) {
         answerRepository.save(answer);
     }

--- a/src/main/java/toy/withme58/api/qustion/service/QuestionService.java
+++ b/src/main/java/toy/withme58/api/qustion/service/QuestionService.java
@@ -56,10 +56,10 @@ public class QuestionService {
     public void updateAnswer(Long answerId, String answerContent) {
         AnswerEntity answer = answerRepository.findById(answerId)
                 .orElseThrow(() -> new ApiException(ErrorCode.NULL_POINT));
-        answer.setAnsweredAt(LocalDateTime.now());
+        answer.setAnsweredAt();
         answer.setContent(answerContent);
         answer.setStatus(AnswerStatus.REGISTERED);
-        answerRepository.save(answer);
+//        answerRepository.save(answer);
     }
 
     @Transactional

--- a/src/main/java/toy/withme58/api/qustion/service/QuestionService.java
+++ b/src/main/java/toy/withme58/api/qustion/service/QuestionService.java
@@ -26,27 +26,23 @@ public class QuestionService {
     public List<QuestionEntity> findAll() {
         return questionRepository.findAll();
     }
-
-    @Transactional
+    
     public List<AnswerEntity> findQuestionsByReceiverId(Long receiverId) { //이떄 답변이 미등록 된 것만 가져온다.
         return answerRepository.findAllByReceiverId(receiverId).stream()
                 .filter(e -> e.getStatus() == AnswerStatus.UNREGISTERED)
                 .toList();
     }
 
-    @Transactional
     public QuestionEntity findQuestionById(Long questionId) {
         return questionRepository.findFirstByIdAndStatusOrderById(questionId, AnswerStatus.REGISTERED)
                 .orElseThrow(() -> new ApiException(ErrorCode.NULL_POINT));
     }
 
-    @Transactional
     public String findQuestionTitle(Long questionId) {
         return questionRepository.findById(questionId)
                 .orElseThrow(() -> new ApiException(ErrorCode.NULL_POINT)).getTitle();
     }
 
-    @Transactional
     public String findFriendNameBySenderId(Long senderId) {
         return memberRepository.findById(senderId)
                 .orElseThrow(() -> new ApiException(ErrorCode.NULL_POINT)).getName();
@@ -62,7 +58,6 @@ public class QuestionService {
 //        answerRepository.save(answer);
     }
 
-    @Transactional
     public AnswerEntity findAnswerById(Long answerId) {
         return answerRepository.findById(answerId).orElseThrow(() -> new ApiException(ErrorCode.NULL_POINT));
     }

--- a/src/main/java/toy/withme58/api/qustion/service/QuestionService.java
+++ b/src/main/java/toy/withme58/api/qustion/service/QuestionService.java
@@ -12,7 +12,6 @@ import toy.withme58.db.member.MemberRepository;
 import toy.withme58.db.question.QuestionEntity;
 import toy.withme58.db.question.QuestionRepository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -53,8 +52,8 @@ public class QuestionService {
         AnswerEntity answer = answerRepository.findById(answerId)
                 .orElseThrow(() -> new ApiException(ErrorCode.NULL_POINT));
         answer.setAnsweredAt();
-        answer.setContent(answerContent);
-        answer.setStatus(AnswerStatus.REGISTERED);
+        answer.setAnswerContent(answerContent);
+        answer.setAnswerStatus(AnswerStatus.REGISTERED);
 //        answerRepository.save(answer);
     }
 

--- a/src/main/java/toy/withme58/api/qustion/service/QuestionService.java
+++ b/src/main/java/toy/withme58/api/qustion/service/QuestionService.java
@@ -26,7 +26,7 @@ public class QuestionService {
     public List<QuestionEntity> findAll() {
         return questionRepository.findAll();
     }
-    
+
     public List<AnswerEntity> findQuestionsByReceiverId(Long receiverId) { //이떄 답변이 미등록 된 것만 가져온다.
         return answerRepository.findAllByReceiverId(receiverId).stream()
                 .filter(e -> e.getStatus() == AnswerStatus.UNREGISTERED)

--- a/src/main/java/toy/withme58/db/answer/AnswerEntity.java
+++ b/src/main/java/toy/withme58/db/answer/AnswerEntity.java
@@ -9,12 +9,11 @@ import toy.withme58.db.question.QuestionEntity;
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Entity
-@Table(name ="answer")
+@Table(name = "answer")
 public class AnswerEntity {
 
     @Id
@@ -41,6 +40,18 @@ public class AnswerEntity {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
-//    @Column(nullable = false)
+    //    @Column(nullable = false)
     private LocalDateTime answeredAt;
+
+    public void setAnsweredAt() {
+        this.answeredAt = LocalDateTime.now();
+    }
+
+    public void setContent(String answerContent) {
+        this.content = answerContent;
+    }
+
+    public void setStatus(AnswerStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/toy/withme58/db/answer/AnswerEntity.java
+++ b/src/main/java/toy/withme58/db/answer/AnswerEntity.java
@@ -47,11 +47,11 @@ public class AnswerEntity {
         this.answeredAt = LocalDateTime.now();
     }
 
-    public void setContent(String answerContent) {
+    public void setAnswerContent(String answerContent) {
         this.content = answerContent;
     }
 
-    public void setStatus(AnswerStatus status) {
+    public void setAnswerStatus(AnswerStatus status) {
         this.status = status;
     }
 }


### PR DESCRIPTION
<!-- 제목 = [기능] : 작업명 -->
<!-- ex) [feat] : Docker 기반의 CI/CD -->

## 🔧 작업 내용
Answer의 db를 관리할 때에 상대에게(receiver) 답변을 받으면 `answerEntity`를 `set` 하고 `save`하는 형식으로 값을 갱신해 주었습니다.
이후 `@Transactional` 어노테이션을 붙였기 때문에 save 메서드는 따로 필요하지 않다고 생각했습니다! 트랜잭션을 관리하여 해당 메서드가 종료되었을 때에 `flush` 될 것이기 때문입니다
또한 엔티티의 무결성 측면에서 값을 자유롭게 변경할 수 있는 `@Setter`의 사용은 지양되는게 맞다고 생각합니다. 따라서 엔티티 내에 필요한 필드값만 값을 지정해주는 set메서드를 작성하고 `@Setter`는 삭제하였습니다.
그리고 우선 저의 파트만 리팩터링 진행하였습니다

**따라서 서버 재배포 후 답변을 주고 받는 로직이 잘 작동되는지(db에 값이 정상적으로 들어오는 지) 확인해야 합니다~!**
pr리뷰 남겨주시고 머지해 주시면 바로 서버 재배포 후 함께 확인해 보아요ㅎㅎ